### PR TITLE
All options not enclosed in quotes but taken separately + Java folder should be used as working directory

### DIFF
--- a/src/universalJavaApplicationStub
+++ b/src/universalJavaApplicationStub
@@ -179,7 +179,6 @@ elif [ -x "$JAVACMD" ]; then
 	export CFProcessPath="$0"
 
 	cd "$JavaFolder"
-	pwd
 
 	# execute Java and set
 	#	- classpath


### PR DESCRIPTION
- All options not enclosed in quotes but taken separately
  otherwise all options were interpreted as one single option
- Java folder should be used as working directory
  it worked with my previous launcher (apple JavaApplicationStub) this way and I need it this way
  because some arguments are interpreted as files to be contained in the working directory

Sorry for two changes in one commit.
I needed the both changes to be able to use your launcher for my project Freeplane

https://github.com/freeplane/freeplane
http://freeplane.sourceforge.net/wiki/index.php/Main_Page

Kind regards,
Dimitry Polivaev
