### PR TITLE
If the JavaX key is used, then replace variables in JVMOptions and Properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ You should get a functional Mac Application Bundle working with both Java distri
 > If you don't want to care about compatibility issues between OS X and Java versions, better use my JarBundler fork (see next example).
 
 ### My JarBundler fork (v2.4) example
-Download the latest release of my JarBundler fork [from it's github repo](https://github.com/tofi86/Jarbundler) and replace your old JarBundler library with the new one.
+Download the latest release of my JarBundler fork [from its github repo](https://github.com/tofi86/Jarbundler) and replace your old JarBundler library with the new one.
 
 Then place the `universalJavaApplicationStub` from this repo in your build resources folder and link it in your ANT task (attribute `stubfile`). Don't forget to set the newly introduced `useJavaXKey` option:
 ```XML

--- a/src/universalJavaApplicationStub
+++ b/src/universalJavaApplicationStub
@@ -158,6 +158,8 @@ if [ $exitcode -eq 0 ]; then
 
 	# read the JVM Options
 	JVMOptions=`/usr/libexec/PlistBuddy -c "print ${JavaKey}:Properties" "${InfoPlistFile}" 2> /dev/null | grep " =" | sed 's/^ */-D/g' | tr '\n' ' ' | sed 's/  */ /g' | sed 's/ = /=/g' | xargs`
+	# replace occurences of $APP_ROOT with its content
+	JVMOptions=`eval "echo ${JVMOptions}"`
 
 	# read StartOnMainThread
 	JVMStartOnMainThread=`/usr/libexec/PlistBuddy -c "print ${JavaKey}:StartOnMainThread" "${InfoPlistFile}" 2> /dev/null`
@@ -181,9 +183,11 @@ if [ $exitcode -eq 0 ]; then
 
 	# read the JVM Arguments
 	JVMArguments=`/usr/libexec/PlistBuddy -c "print ${JavaKey}:Arguments" "${InfoPlistFile}" 2> /dev/null | xargs`
+	# replace occurences of $APP_ROOT with its content
+	JVMArguments=`eval "echo ${JVMArguments}"`
 
-    # read the Java version we want to find
-    JVMVersion=`/usr/libexec/PlistBuddy -c "print ${JavaKey}:JVMVersion" "${InfoPlistFile}" 2> /dev/null | xargs`
+        # read the Java version we want to find
+        JVMVersion=`/usr/libexec/PlistBuddy -c "print ${JavaKey}:JVMVersion" "${InfoPlistFile}" 2> /dev/null | xargs`
 
 # read Info.plist in Oracle style
 else
@@ -200,7 +204,7 @@ else
 
 	# read the JVM Options
 	JVMOptions=`/usr/libexec/PlistBuddy -c "print :JVMOptions" "${InfoPlistFile}" 2> /dev/null | grep " -" | tr -d '\n' | sed 's/  */ /g' | xargs`
-	# replace occurances of $APP_ROOT with it's content
+	# replace occurences of $APP_ROOT with its content
 	JVMOptions=`eval "echo ${JVMOptions}"`
 
 	JVMClassPath="${JavaFolder}/*"
@@ -210,7 +214,7 @@ else
 
 	# read the JVM Arguments
 	JVMArguments=`/usr/libexec/PlistBuddy -c "print :JVMArguments" "${InfoPlistFile}" 2> /dev/null | tr -d '\n' | sed -E 's/Array \{ *(.*) *\}/\1/g' | sed 's/  */ /g' | xargs`
-	# replace occurances of $APP_ROOT with it's content
+	# replace occurences of $APP_ROOT with its content
 	JVMArguments=`eval "echo ${JVMArguments}"`
 fi
 


### PR DESCRIPTION
Expand $APP_ROOT and $JAVAROOT in Apple formatted Plist files so as to match the Oracle format.  Also, minor grammar issues.