### PR TITLE
Reorder search for Java VM locations

### DIFF
--- a/src/universalJavaApplicationStub
+++ b/src/universalJavaApplicationStub
@@ -310,15 +310,15 @@ elif [ ! -z ${JVMVersion} ] ; then
 	# first in "/usr/libexec/java_home" symlinks
 	if [ -x /usr/libexec/java_home ] && /usr/libexec/java_home -F -v ${JVMVersion} > /dev/null ; then
 		JAVACMD="`/usr/libexec/java_home -F -v ${JVMVersion} 2> /dev/null`/bin/java"
-	
-	# then in Apple JRE plugin
-	elif [ -x "${apple_jre_plugin}" ] && JavaVersionSatisfiesRequirement ${apple_jre_version} ${JVMVersion} ; then
-		JAVACMD="${apple_jre_plugin}"
-	
+
 	# then in Oracle JRE plugin
 	elif [ -x "${oracle_jre_plugin}" ] && JavaVersionSatisfiesRequirement ${oracle_jre_version} ${JVMVersion} ; then
 		JAVACMD="${oracle_jre_plugin}"
-	
+
+	# then in Apple JRE plugin
+	elif [ -x "${apple_jre_plugin}" ] && JavaVersionSatisfiesRequirement ${apple_jre_version} ${JVMVersion} ; then
+		JAVACMD="${apple_jre_plugin}"
+
 	else
 		# display error message with applescript
 		osascript -e "tell application \"System Events\" to display dialog \"ERROR launching '${CFBundleName}'\n\nNo suitable Java version found on your system!\nThis program requires Java ${JVMVersion}\nMake sure you install the required Java version.\" with title \"${CFBundleName}\" buttons {\" OK \"} default button 1 with icon path to resource \"${CFBundleIconFile}\" in bundle (path to me)"


### PR DESCRIPTION
We currently search for Apple's JVM first, and only if we don't find
that go look for the Oracle JVM. While that works, it has a major
downside: The Apple JVM is no longer supported by apple, and (on recent
versions of OS X) will issue a warning about it being an older version
of Java.

If we have code that specifies it will work with any version of Java, it
is usually best to use the most recent JVM rather than the oldest one.
Since Oracle's JVMs are actually maintained these days, defaulting to
that seems like a better strategy than defaulting to Apple's JVM.