### PR TITLE
Add support for arrays of VMOptions in Apple style Info.plists

### DIFF
--- a/src/universalJavaApplicationStub
+++ b/src/universalJavaApplicationStub
@@ -180,8 +180,13 @@ if [ $exitcode -eq 0 ]; then
 	# expand variables $APP_PACKAGE, $JAVAROOT, $USER_HOME
 	JVMClassPath=`eval "echo ${JVMClassPath}"`
 
-	# read the JVM Default Options
-	JVMDefaultOptions=`/usr/libexec/PlistBuddy -c "print ${JavaKey}:VMOptions" "${InfoPlistFile}" 2> /dev/null | xargs`
+	# read the JVM Default Options in either Array or String style
+	JVMDefaultOptions_RAW=`/usr/libexec/PlistBuddy -c "print ${JavaKey}:VMOptions" "${InfoPlistFile}" 2> /dev/null | xargs`
+	if [[ $JVMDefaultOptions_RAW == *Array* ]] ; then
+		JVMDefaultOptions=`/usr/libexec/PlistBuddy -c "print ${JavaKey}:VMOptions" "${InfoPlistFile}" 2> /dev/null | grep "    " | sed 's/^ */ /g' | tr -d '\n' | xargs`
+	else
+		JVMDefaultOptions=${JVMDefaultOptions_RAW}
+	fi
 
 	# read the JVM Arguments
 	JVMArguments=`/usr/libexec/PlistBuddy -c "print ${JavaKey}:Arguments" "${InfoPlistFile}" 2> /dev/null | xargs`


### PR DESCRIPTION
Apple style Info.plist files can have strings or arrays for the VMOptions key (https://developer.apple.com/library/mac/documentation/Java/Reference/Java_InfoplistRef/Articles/JavaDictionaryInfo.plistKeys.html).  This patch adds support for arrays.