### PR TITLE
Allow specifying `JAVA_HOME` relative to `$AppPackageFolder` (for bundling JRE/JDK)

### DIFF
--- a/src/universalJavaApplicationStub
+++ b/src/universalJavaApplicationStub
@@ -302,7 +302,11 @@ oracle_jre_version=`extractJavaMajorVersion "${oracle_jre_plugin}"`
 
 # first check system variable "$JAVA_HOME"
 if [ -n "$JAVA_HOME" ] ; then
-	JAVACMD="$JAVA_HOME/bin/java"
+    if [[ $JAVA_HOME == /* ]] ; then
+	    JAVACMD="$JAVA_HOME/bin/java"
+    else
+        JAVACMD="$AppPackageFolder/$JAVA_HOME/bin/java"
+    fi
 	
 # check for JVMversion requirements
 elif [ ! -z ${JVMVersion} ] ; then


### PR DESCRIPTION
One may wish, for example, to bundle the JRE with their application.  When doing so, it is helpful to specify the `JAVA_HOME` relative to the application package folder.  This patch will prepend `$AppPackageFolder` to `JAVA_HOME` when looking for `JAVACMD` - but _ONLY_ if `JAVA_HOME` is a relative path (doesn't start with `/`).  This allows you to set a relative `JAVA_HOME` using `<lsenvironment>` and it will get picked up.
