### PR TITLE
Pass command line arguments through to the application

### DIFF
--- a/src/universalJavaApplicationStub
+++ b/src/universalJavaApplicationStub
@@ -374,19 +374,16 @@ elif [ -f "$JAVACMD" ] && [ -x "$JAVACMD" ] ; then
 	#	- JVM default options
 	#	- main class
 	#	- JVM arguments
-	command="$JAVACMD"
-        command+=" -cp ${JVMClassPath}"
-        command+=" -splash:${ResourcesFolder}/${JVMSplashFile}"
-        command+=" -Xdock:icon=${ResourcesFolder}/${CFBundleIconFile}"
-        command+=" -Xdock:name=${CFBundleName}"
-        command+=" ${JVMOptions:+$JVMOptions}"
-        command+=" ${JVMDefaultOptions:+$JVMDefaultOptions}"
-        command+="  ${JVMMainClass}"
-        command+=" ${JVMArguments:+ $JVMArguments}"
-        if [ "$#" -ne 0 ]; then
-                command+=" $@"
-        fi
-
+	exec "$JAVACMD" \
+			-cp "${JVMClassPath}" \
+			-splash:"${ResourcesFolder}/${JVMSplashFile}" \
+			-Xdock:icon="${ResourcesFolder}/${CFBundleIconFile}" \
+			-Xdock:name="${CFBundleName}" \
+			${JVMOptions:+$JVMOptions }\
+			${JVMDefaultOptions:+$JVMDefaultOptions }\
+			${JVMMainClass}\
+			${JVMArguments:+ $JVMArguments}\
+			"$@"
 
 
 else

--- a/src/universalJavaApplicationStub
+++ b/src/universalJavaApplicationStub
@@ -382,7 +382,8 @@ elif [ -f "$JAVACMD" ] && [ -x "$JAVACMD" ] ; then
 			${JVMOptions:+$JVMOptions }\
 			${JVMDefaultOptions:+$JVMDefaultOptions }\
 			${JVMMainClass}\
-			${JVMArguments:+ $JVMArguments}
+			${JVMArguments:+ $JVMArguments}\
+			$@
 
 
 else

--- a/src/universalJavaApplicationStub
+++ b/src/universalJavaApplicationStub
@@ -374,16 +374,19 @@ elif [ -f "$JAVACMD" ] && [ -x "$JAVACMD" ] ; then
 	#	- JVM default options
 	#	- main class
 	#	- JVM arguments
-	exec "$JAVACMD" \
-			-cp "${JVMClassPath}" \
-			-splash:"${ResourcesFolder}/${JVMSplashFile}" \
-			-Xdock:icon="${ResourcesFolder}/${CFBundleIconFile}" \
-			-Xdock:name="${CFBundleName}" \
-			${JVMOptions:+$JVMOptions }\
-			${JVMDefaultOptions:+$JVMDefaultOptions }\
-			${JVMMainClass}\
-			${JVMArguments:+ $JVMArguments}\
-			$@
+	command="$JAVACMD"
+        command+=" -cp ${JVMClassPath}"
+        command+=" -splash:${ResourcesFolder}/${JVMSplashFile}"
+        command+=" -Xdock:icon=${ResourcesFolder}/${CFBundleIconFile}"
+        command+=" -Xdock:name=${CFBundleName}"
+        command+=" ${JVMOptions:+$JVMOptions}"
+        command+=" ${JVMDefaultOptions:+$JVMDefaultOptions}"
+        command+="  ${JVMMainClass}"
+        command+=" ${JVMArguments:+ $JVMArguments}"
+        if [ "$#" -ne 0 ]; then
+                command+=" $@"
+        fi
+
 
 
 else


### PR DESCRIPTION
Currently, you cannot pass command line arguments to the bundled application. For instance:
`open MyJavaApp.app --args arg1 arg2`
`arg1` and `arg2` are available in the `universalJavaApplicationStub` script, but it doesn't forward them in the call to java.
This commit just tacks a `$@` on the end of the call to `exec "$JAVACMD"`