### PR TITLE
Priority to the Oracle JRE

### DIFF
--- a/src/universalJavaApplicationStub
+++ b/src/universalJavaApplicationStub
@@ -307,13 +307,13 @@ if [ -n "$JAVA_HOME" ] ; then
 # check for JVMversion requirements
 elif [ ! -z ${JVMVersion} ] ; then
 
-	# first in "/usr/libexec/java_home" symlinks
-	if [ -x /usr/libexec/java_home ] && /usr/libexec/java_home -F -v ${JVMVersion} > /dev/null ; then
-		JAVACMD="`/usr/libexec/java_home -F -v ${JVMVersion} 2> /dev/null`/bin/java"
-
-	# then in Oracle JRE plugin
-	elif [ -x "${oracle_jre_plugin}" ] && JavaVersionSatisfiesRequirement ${oracle_jre_version} ${JVMVersion} ; then
+	# first in Oracle JRE plugin
+	if [ -x "${oracle_jre_plugin}" ] && JavaVersionSatisfiesRequirement ${oracle_jre_version} ${JVMVersion} ; then
 		JAVACMD="${oracle_jre_plugin}"
+
+	# then in "/usr/libexec/java_home" symlinks
+	elif [ -x /usr/libexec/java_home ] && /usr/libexec/java_home -F -v ${JVMVersion} > /dev/null ; then
+		JAVACMD="`/usr/libexec/java_home -F -v ${JVMVersion} 2> /dev/null`/bin/java"
 
 	# then in Apple JRE plugin
 	elif [ -x "${apple_jre_plugin}" ] && JavaVersionSatisfiesRequirement ${apple_jre_version} ${JVMVersion} ; then


### PR DESCRIPTION
Hi,

I'd like to suggest this change to use the Oracle JRE in priority over the other runtimes. I have a Java application requiring Java > 6 and the launcher always picks the old Apple JRE even if a more recent Oracle JRE is available. This is annoying because I can't increase the version of Java required for my application until I notice a significant drop in Java 6 usage on OS X, and if the Oracle JRE doesn't have the priority it never happens.