### PR TITLE
Do not expand folder/* classpath

### DIFF
--- a/src/universalJavaApplicationStub
+++ b/src/universalJavaApplicationStub
@@ -218,14 +218,18 @@ else
 	JVMClassPath_RAW=`/usr/libexec/PlistBuddy -c "print JVMClassPath" "${InfoPlistFile}" 2> /dev/null`
 	if [[ $JVMClassPath_RAW == *Array* ]] ; then
 		JVMClassPath=.`/usr/libexec/PlistBuddy -c "print JVMClassPath" "${InfoPlistFile}" 2> /dev/null | grep "    " | sed 's/^ */:/g' | tr -d '\n' | xargs`
+
+        # expand variables $APP_PACKAGE, $JAVAROOT, $USER_HOME
+        JVMClassPath=`eval "echo ${JVMClassPath}"`
 	elif [[ ! -z ${JVMClassPath_RAW} ]] ; then
 		JVMClassPath=${JVMClassPath_RAW}
+
+        # expand variables $APP_PACKAGE, $JAVAROOT, $USER_HOME
+        JVMClassPath=`eval "echo ${JVMClassPath}"`
 	else
 		#default: fallback to OracleJavaFolder
 		JVMClassPath="${JavaFolder}/*"
 	fi
-	# expand variables $APP_PACKAGE, $JAVAROOT, $USER_HOME
-	JVMClassPath=`eval "echo ${JVMClassPath}"`
 
 	# read the JVM Default Options
 	JVMDefaultOptions=`/usr/libexec/PlistBuddy -c "print :JVMDefaultOptions" "${InfoPlistFile}" 2> /dev/null | grep -o " \-.*" | tr -d '\n' | xargs`


### PR DESCRIPTION
UniversalJavaApplicationStub 2.0.1 expands defaults lib/* path instead of passing it directly to java command line.

DavMail relies on your script to replace old binary Java launchers, it works great except for this issue.
See https://sourceforge.net/p/davmail/support-requests/300/ for more details.

Patch moves variable expansion to all cases except OracleJavaFolder fallback.