### PR TITLE
Release version 3.0.2

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -24,7 +24,7 @@ I'm submitting a…
 
 **Do you have screenshots, GIFs, demos or samples which demonstrate the problem or enhancement?**
 
-![image description](url)
+
 
 **What is the motivation / use case for changing the behavior?**
 
@@ -32,6 +32,7 @@ I'm submitting a…
 
 **Please tell us about your environment:**
 
+- universalJavaApplicationStub version:
 - Mac OS version:
 - Java version(s):
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,8 +2,8 @@
 
 (Add x between brackets to check.)
 
+- [ ] I’ve updated my fork from the `develop` branch before proposing this pull request
 - [ ] I’m making this pull request against the `develop` branch
-- [ ] I’ve updated from the `develop` branch before proposing this pull request
 - [ ] I’ve tested the changes for bug fixes and/or features
 - [ ] I’ve documented new code
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,23 @@ matrix:
       osx_image: xcode9.3
 
 
+install:
+  - brew install shellcheck
+
+
+before_script:
+  - sw_vers
+  - shellcheck -V
+
+
 # run the 'java-version-tester' script and show&save (`tee`) the output to a
 # logfile; then grep the logfile for 'FAILED' entries which would cause grep
 # to exit with 0; then run 'test' command and swap the grep exit code
 # to return with 0 if grep doesn't match and return with 1 if it matches
 script:
-  - sw_vers
   - bash test/java-version-tester.sh | tee test/java-version-tester.log
   - cat test/java-version-tester.log | grep FAILED ; test $? -eq 1
+  # test with shellcheck for bash syntax errors which should fail the build
+  # grep for errors until shellcheck issue / feature request
+  # https://github.com/koalaman/shellcheck/issues/524 is implemented
+  - shellcheck -s bash -f gcc src/universalJavaApplicationStub | grep "error:" ; test $? -eq 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,14 @@ matrix:
       osx_image: xcode9.3
 
 
+# Homebrew needs ruby 2.3 and should be updated everytime to use the latest
+# version of shellcheck
+before_install:
+  - rvm install 2.3.0
+  - brew update
+
 install:
   - brew install shellcheck
-
 
 before_script:
   - sw_vers

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ language: generic
 # https://docs.travis-ci.com/user/reference/osx/#OS-X-Version
 matrix:
   include:
-    # OS X 10.10
-    - os: osx
-      osx_image: xcode6.4
     # OS X 10.11
     - os: osx
       osx_image: xcode8

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
       osx_image: xcode9
     # OS X 10.13
     - os: osx
-      osx_image: xcode9.3beta
+      osx_image: xcode9.3
 
 
 # run the 'java-version-tester' script and show&save (`tee`) the output to a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ChangeLog
 ---------
 
+### v3.0.2 (2018-04-12)
+* Bugfix: fix typo in JVMOptions expansion on java exec call (PR #63, Thanks to @michaelweiser for his contribution)
+* Added a basic Travis CI build pipeline running a `shellcheck` test for errors and executing the basic testsuite
+
 ### v3.0.1 (2018-03-10)
 * Bugfix: remove build number from JVM version number when creating comparable version number or extracting major version (fixes #61)
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ How the script works
 
 You don't need a native `JavaApplicationStub` file anymore. The Bash script needs to be executable – that's all.
 
-The script reads JVM properties from `Info.plist` regardless of whether it's Apple or Oracle syntax and feeds them to a commandline `java` call like the following:
+The script reads JVM properties from `Info.plist` regardless of whether it's Apple or Oracle syntax and passes them to a `exec java` call like the following simplified:
 
 ```Bash
 # execute Java and set
@@ -51,21 +51,21 @@ The script reads JVM properties from `Info.plist` regardless of whether it's App
 # - splash image
 # - dock icon
 # - app name
-# - JVM options
-# - JVM default options
+# - JVM options / properties (-D)
+# - JVM default options (-X)
 # - main class
-# - main arguments
-# - passthru arguments
+# - main class arguments
+# - passthrough arguments from Terminal or Drag'n'Drop to Finder icon
 exec "${JAVACMD}" \
     -cp "${JVMClassPath}" \
     -splash:"${ResourcesFolder}/${JVMSplashFile}" \
     -Xdock:icon="${ResourcesFolder}/${CFBundleIconFile}" \
     -Xdock:name="${CFBundleName}" \
-    ${JVMOptions:+$JVMOptions }\
-    ${JVMDefaultOptions:+$JVMDefaultOptions }\
-    ${JVMMainClass}\
-    ${MainArgs:+ $MainArgs}\
-    ${ArgsPassthru:+ $ArgsPassthru}
+    ${JVMOptions} \
+    ${JVMDefaultOptions} \
+    ${JVMMainClass} \
+    ${MainArgsArr} \
+    ${ArgsPassthru}
 ```
 
 It sets the classpath, the dock icon, the *AboutMenuName* (as Xdock parameter) and then every *JVMOptions*, *JVMDefaultOptions* or *JVMArguments* found in the `Info.plist` file. See the table below for more supported Plist keys.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 universalJavaApplicationStub
 ============================
 
-[![Current release](https://img.shields.io/github/release/tofi86/universalJavaApplicationStub.svg)](https://github.com/tofi86/universalJavaApplicationStub/releases) [![Join the chat at https://gitter.im/tofi86/universalJavaApplicationStub](https://badges.gitter.im/tofi86/universalJavaApplicationStub.svg)](https://gitter.im/tofi86/universalJavaApplicationStub?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://travis-ci.org/tofi86/universalJavaApplicationStub.svg?branch=master)](https://travis-ci.org/tofi86/universalJavaApplicationStub) [![Current release](https://img.shields.io/github/release/tofi86/universalJavaApplicationStub.svg)](https://github.com/tofi86/universalJavaApplicationStub/releases) [![Join the chat at https://gitter.im/tofi86/universalJavaApplicationStub](https://badges.gitter.im/tofi86/universalJavaApplicationStub.svg)](https://gitter.im/tofi86/universalJavaApplicationStub?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 A BASH based *JavaApplicationStub* for Java Apps on Mac OS X that works with both Apple's and Oracle's plist format. It is released under the [MIT License](https://github.com/tofi86/universalJavaApplicationStub/blob/master/LICENSE).
 

--- a/src/universalJavaApplicationStub
+++ b/src/universalJavaApplicationStub
@@ -756,11 +756,11 @@ stub_logger "[WorkingDirectory] ${WorkingDirectory}"
 # - splash image
 # - dock icon
 # - app name
-# - JVM options
-# - JVM default options
+# - JVM options / properties (-D)
+# - JVM default options (-X)
 # - main class
-# - main arguments
-# - passthru arguments
+# - main class arguments
+# - passthrough arguments from Terminal or Drag'n'Drop to Finder icon
 stub_logger "[Exec] \"$JAVACMD\" -cp \"${JVMClassPath}\" -splash:\"${ResourcesFolder}/${JVMSplashFile}\" -Xdock:icon=\"${ResourcesFolder}/${CFBundleIconFile}\" -Xdock:name=\"${CFBundleName}\" ${JVMOptionsArr:+$(printf "'%s' " "${JVMOptionsArr[@]}") }${JVMDefaultOptions:+$JVMDefaultOptions }${JVMMainClass}${MainArgsArr:+ $(printf "'%s' " "${MainArgsArr[@]}")}${ArgsPassthru:+ $(printf "'%s' " "${ArgsPassthru[@]}")}"
 exec "${JAVACMD}" \
 		-cp "${JVMClassPath}" \

--- a/src/universalJavaApplicationStub
+++ b/src/universalJavaApplicationStub
@@ -11,8 +11,8 @@
 #                                                                                #
 # @author    Tobias Fischer                                                      #
 # @url       https://github.com/tofi86/universalJavaApplicationStub              #
-# @date      2018-03-10                                                          #
-# @version   3.0.1                                                               #
+# @date      2018-04-12                                                          #
+# @version   3.0.2                                                               #
 #                                                                                #
 ##################################################################################
 #                                                                                #

--- a/src/universalJavaApplicationStub
+++ b/src/universalJavaApplicationStub
@@ -767,7 +767,7 @@ exec "${JAVACMD}" \
 		-splash:"${ResourcesFolder}/${JVMSplashFile}" \
 		-Xdock:icon="${ResourcesFolder}/${CFBundleIconFile}" \
 		-Xdock:name="${CFBundleName}" \
-		${JVMOptions:+"$JVMOptions[@]}" }\
+		${JVMOptions:+"${JVMOptions[@]}" }\
 		${JVMDefaultOptions:+$JVMDefaultOptions }\
 		"${JVMMainClass}"\
 		${MainArgsArr:+ "${MainArgsArr[@]}"}\

--- a/src/universalJavaApplicationStub
+++ b/src/universalJavaApplicationStub
@@ -741,7 +741,7 @@ fi
 export CFProcessPath="$0"
 
 # remove Apples ProcessSerialNumber from passthru arguments (#39)
-if [[ $@ == -psn* ]] ; then
+if [[ "$*" == -psn* ]] ; then
 	ArgsPassthru=()
 else
 	ArgsPassthru=("$@")


### PR DESCRIPTION
### v3.0.2 (2018-04-12)
* Bugfix: fix typo in JVMOptions expansion on java exec call (PR #63, Thanks to @michaelweiser for his contribution)
* Added a basic Travis CI build pipeline running a `shellcheck` test for errors and executing the basic testsuite