### PR TITLE
Release version 3.0.5 (PR #79)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,21 @@
 language: generic
 
 # run on different Mac OS X versions
-# https://docs.travis-ci.com/user/reference/osx/#OS-X-Version
+# https://docs.travis-ci.com/user/reference/osx/#macos-version
 matrix:
   include:
-    # OS X 10.11
+    # OS X 10.12, Java 8
     - os: osx
-      osx_image: xcode8
-    # OS X 10.12
+      osx_image: xcode9.2
+    # OS X 10.13, Java 10
     - os: osx
-      osx_image: xcode9
-    # OS X 10.13
+      osx_image: xcode10
+    # OS X 10.13, Java 11
     - os: osx
-      osx_image: xcode9.3
+      osx_image: xcode10.1
+    # OS X 10.14, Java 12
+    - os: osx
+      osx_image: xcode11
 
 
 # Homebrew needs ruby 2.3 and should be updated everytime to use the latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ChangeLog
 ---------
 
+### v3.0.5 (2019-12-15)
+* If java is missing, offer a choice between Oracle and AdoptOpenJDK download buttons (#78)
+* Support Array style `Java:Arguments` for Apple Plist style (#76)
+* Bugfix: do not crash if `CFBundleIconFile` is provided without ".icns" extension (#75)
+* Minor French translation fix (PR #73, Thanks to @ebourg for his contribution)
+
 ### v3.0.4 (2018-08-24)
 * Bugfix: Variables `$APP_PACKAGE`, `$JAVAROOT`, `$USER_HOME` in `JVMOptions` key (Oracle) or `Java:Properties` key (Apple) were not expanded (#69)
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Use whichever ANT task you like:
 * Oracle's opensource ["Appbundler"](https://java.net/projects/appbundler) *(seems to be dead)*
   * or [*infinitekind*'s fork](https://bitbucket.org/infinitekind/appbundler/overview)
 
+Or build the App bundle statically from scratch...
+
 ### JarBundler (≥ v3.3) example
 Download the latest JarBundler release [from its github repo](https://github.com/UltraMixer/JarBundler).
 
@@ -162,6 +164,23 @@ Supported PList keys
 | **`-XstartOnFirstThread`** [*](https://stackoverflow.com/questions/28149634/what-does-the-xstartonfirstthread-vm-argument-do-mean) | `:Java(X):StartOnMainThread` | *not supported*       |
 | **Java Properties** (`-D…`)     | `:Java(X):Properties`  | `:JVMOptions`         |
 | **Main Class Arguments**        | `:Java(X):Arguments`   | `:JVMArguments`       |
+
+
+Recommended additional Plist keys
+---------------------------------
+
+Starting with Mac OS 10.14 users may be confronted with an additional system security dialog before any warning dialog of this stub is shown. See [issue #77](https://github.com/tofi86/universalJavaApplicationStub/issues/77) for more details.
+
+This happens because the warning dialogs of this launcher stub are displayed with AppleScript.
+
+It's recommended to at least set the following Plist key in order to display a descriptive message to the user, why he should grant the app system access:
+
+```xml
+<key>NSAppleEventsUsageDescription</key>
+<string>There was an error while launching the application. Please click OK to display a dialog with more information or cancel and view the syslog for details.</string>
+```
+
+The message itself is just a sample...
 
 
 Logging

--- a/README.md
+++ b/README.md
@@ -166,6 +166,32 @@ Supported PList keys
 | **Main Class Arguments**        | `:Java(X):Arguments`   | `:JVMArguments`       |
 
 
+### Specify min/max Java requirement
+
+Since v3.0 ([#51](https://github.com/tofi86/universalJavaApplicationStub/issues/51))
+
+Use `Java(X):JVMVersion` (Apple style) or `:JVMVersion` (Oracle style) with the following values:
+
+* `1.8` or `1.8*` for Java 8
+* `1.8+` for Java 8 or higher
+* `1.7;1.8*` for Java 7 or 8
+* `1.8;9.0` for Java 8* up to exactly 9.0 (but not 9.0.*)
+* `1.8;9.0*` for Java 8* and 9.0.* but not 9.1.*
+
+
+### Bundle a JRE/JDK with your app
+
+You can use the Plist key `LSEnvironment` to export and set the `$JAVA_HOME` environment variable relative to your App's root directory:
+
+```xml
+<key>LSEnvironment</key>
+<dict>
+    <key>JAVA_HOME</key>
+    <string>Contents/Frameworks/jdk8u232-b09-jre/Contents/Home</string>
+<dict>
+```
+
+
 Recommended additional Plist keys
 ---------------------------------
 

--- a/src/universalJavaApplicationStub
+++ b/src/universalJavaApplicationStub
@@ -11,8 +11,8 @@
 #                                                                                #
 # @author    Tobias Fischer                                                      #
 # @url       https://github.com/tofi86/universalJavaApplicationStub              #
-# @date      2019-12-09                                                          #
-# @version   3.0.4                                                               #
+# @date      2019-12-15                                                          #
+# @version   3.0.5                                                               #
 #                                                                                #
 ##################################################################################
 #                                                                                #

--- a/src/universalJavaApplicationStub
+++ b/src/universalJavaApplicationStub
@@ -11,7 +11,7 @@
 #                                                                                #
 # @author    Tobias Fischer                                                      #
 # @url       https://github.com/tofi86/universalJavaApplicationStub              #
-# @date      2018-08-24                                                          #
+# @date      2019-12-08                                                          #
 # @version   3.0.4                                                               #
 #                                                                                #
 ##################################################################################
@@ -220,9 +220,14 @@ if [ $exitcode -eq 0 ]; then
 		JVMDefaultOptions+=" -XstartOnFirstThread"
 	fi
 
-	# read the JVM Arguments as an array and retain spaces
+	# read the JVM Arguments in either Array or String style (#76) and retain spaces
 	IFS=$'\t\n'
-	MainArgs=($(xargs -n1 <<<$(plist_get_java ':Arguments')))
+	MainArgs_RAW=$(plist_get_java ':Arguments' | xargs)
+	if [[ $MainArgs_RAW == *Array* ]] ; then
+		MainArgs=($(xargs -n1 <<<$(plist_get_java ':Arguments' | tr -d '\n' | sed -E 's/Array \{ *(.*) *\}/\1/g' | sed 's/  */ /g')))
+	else
+		MainArgs=($(xargs -n1 <<<$(plist_get_java ':Arguments')))
+	fi
 	unset IFS
 	# post processing of the array follows further below...
 

--- a/src/universalJavaApplicationStub
+++ b/src/universalJavaApplicationStub
@@ -11,7 +11,7 @@
 #                                                                                #
 # @author    Tobias Fischer                                                      #
 # @url       https://github.com/tofi86/universalJavaApplicationStub              #
-# @date      2019-12-08                                                          #
+# @date      2019-12-09                                                          #
 # @version   3.0.4                                                               #
 #                                                                                #
 ##################################################################################
@@ -292,6 +292,18 @@ else
 fi
 
 
+# (#75) check for undefined icons or icon names without .icns extension and prepare
+# an osascript statement for those cases when the icon can be shown in the dialog
+DialogWithIcon=""
+if [ ! -z ${CFBundleIconFile} ]; then
+	if [[ ${CFBundleIconFile} == *.icns ]] && [[ -f "${ResourcesFolder}/${CFBundleIconFile}" ]] ; then
+		DialogWithIcon=" with icon path to resource \"${CFBundleIconFile}\" in bundle (path to me)"
+	elif [[ ${CFBundleIconFile} != *.icns ]] && [[ -f "${ResourcesFolder}/${CFBundleIconFile}.icns" ]] ; then
+		CFBundleIconFile+=".icns"
+		DialogWithIcon=" with icon path to resource \"${CFBundleIconFile}\" in bundle (path to me)"
+	fi
+fi
+
 
 # JVMVersion: post processing and optional splitting
 if [[ ${JVMVersion} == *";"* ]]; then
@@ -518,7 +530,7 @@ if [ -z "${JAVACMD}" ] || [ ! -x "${JAVACMD}" ] ; then
 		# log exit cause
 		stub_logger "[EXIT 4] ${MSG_JVMVERSION_REQ_INVALID_EXPANDED}"
 		# display error message with AppleScript
-		osascript -e "tell application \"System Events\" to display dialog \"${MSG_ERROR_LAUNCHING}\n\n${MSG_JVMVERSION_REQ_INVALID_EXPANDED}\" with title \"${CFBundleName}\" buttons {\" OK \"} default button 1 with icon path to resource \"${CFBundleIconFile}\" in bundle (path to me)"
+		osascript -e "tell application \"System Events\" to display dialog \"${MSG_ERROR_LAUNCHING}\n\n${MSG_JVMVERSION_REQ_INVALID_EXPANDED}\" with title \"${CFBundleName}\" buttons {\" OK \"} default button 1${DialogWithIcon}"
 		# exit with error
 		exit 4
 	fi
@@ -528,7 +540,7 @@ if [ -z "${JAVACMD}" ] || [ ! -x "${JAVACMD}" ] ; then
 		# log exit cause
 		stub_logger "[EXIT 5] ${MSG_JVMVERSION_REQ_INVALID_EXPANDED}"
 		# display error message with AppleScript
-		osascript -e "tell application \"System Events\" to display dialog \"${MSG_ERROR_LAUNCHING}\n\n${MSG_JVMVERSION_REQ_INVALID_EXPANDED}\" with title \"${CFBundleName}\" buttons {\" OK \"} default button 1 with icon path to resource \"${CFBundleIconFile}\" in bundle (path to me)"
+		osascript -e "tell application \"System Events\" to display dialog \"${MSG_ERROR_LAUNCHING}\n\n${MSG_JVMVERSION_REQ_INVALID_EXPANDED}\" with title \"${CFBundleName}\" buttons {\" OK \"} default button 1${DialogWithIcon}"
 		# exit with error
 		exit 5
 	fi
@@ -705,7 +717,7 @@ if [ -z "${JAVACMD}" ] || [ ! -x "${JAVACMD}" ] ; then
 		stub_logger "[EXIT 3] ${MSG_NO_SUITABLE_JAVA_EXPANDED}"
 
 		# display error message with AppleScript
-		osascript -e "tell application \"System Events\" to display dialog \"${MSG_ERROR_LAUNCHING}\n\n${MSG_NO_SUITABLE_JAVA_EXPANDED}\n${MSG_NO_SUITABLE_JAVA_CHECK}\" with title \"${CFBundleName}\"  buttons {\" OK \", \"${MSG_VISIT_JAVA_DOT_COM}\"} default button \"${MSG_VISIT_JAVA_DOT_COM}\" with icon path to resource \"${CFBundleIconFile}\" in bundle (path to me)" \
+		osascript -e "tell application \"System Events\" to display dialog \"${MSG_ERROR_LAUNCHING}\n\n${MSG_NO_SUITABLE_JAVA_EXPANDED}\n${MSG_NO_SUITABLE_JAVA_CHECK}\" with title \"${CFBundleName}\"  buttons {\" OK \", \"${MSG_VISIT_JAVA_DOT_COM}\"} default button \"${MSG_VISIT_JAVA_DOT_COM}\"${DialogWithIcon}" \
 				-e "set response to button returned of the result" \
 				-e "if response is \"${MSG_VISIT_JAVA_DOT_COM}\" then open location \"http://java.com\""
 		# exit with error
@@ -715,7 +727,7 @@ if [ -z "${JAVACMD}" ] || [ ! -x "${JAVACMD}" ] ; then
 		# log exit cause
 		stub_logger "[EXIT 1] ${MSG_ERROR_LAUNCHING}"
 		# display error message with AppleScript
-		osascript -e "tell application \"System Events\" to display dialog \"${MSG_ERROR_LAUNCHING}\n\n${MSG_INSTALL_JAVA}\" with title \"${CFBundleName}\" buttons {\"${MSG_LATER}\", \"${MSG_VISIT_JAVA_DOT_COM}\"} default button \"${MSG_VISIT_JAVA_DOT_COM}\" with icon path to resource \"${CFBundleIconFile}\" in bundle (path to me)" \
+		osascript -e "tell application \"System Events\" to display dialog \"${MSG_ERROR_LAUNCHING}\n\n${MSG_INSTALL_JAVA}\" with title \"${CFBundleName}\" buttons {\"${MSG_LATER}\", \"${MSG_VISIT_JAVA_DOT_COM}\"} default button \"${MSG_VISIT_JAVA_DOT_COM}\"${DialogWithIcon}" \
 					-e "set response to button returned of the result" \
 					-e "if response is \"${MSG_VISIT_JAVA_DOT_COM}\" then open location \"http://java.com\""
 		# exit with error
@@ -732,7 +744,7 @@ if [ -z "${JVMMainClass}" ]; then
 	# log exit cause
 	stub_logger "[EXIT 2] ${MSG_MISSING_MAINCLASS}"
 	# display error message with AppleScript
-	osascript -e "tell application \"System Events\" to display dialog \"${MSG_ERROR_LAUNCHING}\n\n${MSG_MISSING_MAINCLASS}\" with title \"${CFBundleName}\" buttons {\" OK \"} default button 1 with icon path to resource \"${CFBundleIconFile}\" in bundle (path to me)"
+	osascript -e "tell application \"System Events\" to display dialog \"${MSG_ERROR_LAUNCHING}\n\n${MSG_MISSING_MAINCLASS}\" with title \"${CFBundleName}\" buttons {\" OK \"} default button 1${DialogWithIcon}"
 	# exit with error
 	exit 2
 fi

--- a/src/universalJavaApplicationStub
+++ b/src/universalJavaApplicationStub
@@ -339,7 +339,7 @@ stub_logger "[Language] $LANG"
 if [[ $LANG == fr* ]] ; then
 	MSG_ERROR_LAUNCHING="ERREUR au lancement de '${CFBundleName}'."
 	MSG_MISSING_MAINCLASS="'MainClass' n'est pas spécifié.\nL'application Java ne peut pas être lancée."
-	MSG_JVMVERSION_REQ_INVALID="La syntaxe de la version Java demandée est invalide: %s\nVeuillez contacter le développeur de l'application."
+	MSG_JVMVERSION_REQ_INVALID="La syntaxe de la version de Java demandée est invalide: %s\nVeuillez contacter le développeur de l'application."
 	MSG_NO_SUITABLE_JAVA="La version de Java installée sur votre système ne convient pas.\nCe programme nécessite Java %s"
 	MSG_JAVA_VERSION_OR_LATER="ou ultérieur"
 	MSG_JAVA_VERSION_LATEST="(dernière mise à jour)"

--- a/src/universalJavaApplicationStub
+++ b/src/universalJavaApplicationStub
@@ -347,7 +347,8 @@ if [[ $LANG == fr* ]] ; then
 	MSG_NO_SUITABLE_JAVA_CHECK="Merci de bien vouloir installer la version de Java requise."
 	MSG_INSTALL_JAVA="Java doit être installé sur votre système.\nRendez-vous sur java.com et suivez les instructions d'installation..."
 	MSG_LATER="Plus tard"
-	MSG_VISIT_JAVA_DOT_COM="Visiter java.com"
+	MSG_VISIT_JAVA_DOT_COM="Java by Oracle"
+	MSG_VISIT_ADOPTOPENJDK="Java by AdoptOpenJDK"
 
 # German localization
 elif [[ $LANG == de* ]] ; then
@@ -361,7 +362,8 @@ elif [[ $LANG == de* ]] ; then
 	MSG_NO_SUITABLE_JAVA_CHECK="Stellen Sie sicher, dass die angeforderte Java-Version installiert ist."
 	MSG_INSTALL_JAVA="Auf Ihrem System muss die 'Java'-Software installiert sein.\nBesuchen Sie java.com für weitere Installationshinweise."
 	MSG_LATER="Später"
-	MSG_VISIT_JAVA_DOT_COM="java.com öffnen"
+	MSG_VISIT_JAVA_DOT_COM="Java von Oracle"
+	MSG_VISIT_ADOPTOPENJDK="Java von AdoptOpenJDK"
 
 # Simplifyed Chinese localization
 elif [[ $LANG == zh* ]] ; then
@@ -375,7 +377,8 @@ elif [[ $LANG == zh* ]] ; then
 	MSG_NO_SUITABLE_JAVA_CHECK="请确保系统中安装了所需的Java版本"
 	MSG_INSTALL_JAVA="你需要在Mac中安装Java运行环境！\n访问 java.com 了解如何安装。"
 	MSG_LATER="稍后"
-	MSG_VISIT_JAVA_DOT_COM="访问 java.com"
+	MSG_VISIT_JAVA_DOT_COM="Java by Oracle"
+	MSG_VISIT_ADOPTOPENJDK="Java by AdoptOpenJDK"
 
 # English default localization
 else
@@ -389,7 +392,8 @@ else
 	MSG_NO_SUITABLE_JAVA_CHECK="Make sure you install the required Java version."
 	MSG_INSTALL_JAVA="You need to have JAVA installed on your Mac!\nVisit java.com for installation instructions..."
 	MSG_LATER="Later"
-	MSG_VISIT_JAVA_DOT_COM="Visit java.com"
+	MSG_VISIT_JAVA_DOT_COM="Java by Oracle"
+	MSG_VISIT_ADOPTOPENJDK="Java by AdoptOpenJDK"
 fi
 
 
@@ -717,9 +721,10 @@ if [ -z "${JAVACMD}" ] || [ ! -x "${JAVACMD}" ] ; then
 		stub_logger "[EXIT 3] ${MSG_NO_SUITABLE_JAVA_EXPANDED}"
 
 		# display error message with AppleScript
-		osascript -e "tell application \"System Events\" to display dialog \"${MSG_ERROR_LAUNCHING}\n\n${MSG_NO_SUITABLE_JAVA_EXPANDED}\n${MSG_NO_SUITABLE_JAVA_CHECK}\" with title \"${CFBundleName}\"  buttons {\" OK \", \"${MSG_VISIT_JAVA_DOT_COM}\"} default button \"${MSG_VISIT_JAVA_DOT_COM}\"${DialogWithIcon}" \
+		osascript -e "tell application \"System Events\" to display dialog \"${MSG_ERROR_LAUNCHING}\n\n${MSG_NO_SUITABLE_JAVA_EXPANDED}\n${MSG_NO_SUITABLE_JAVA_CHECK}\" with title \"${CFBundleName}\"  buttons {\" OK \", \"${MSG_VISIT_JAVA_DOT_COM}\", \"${MSG_VISIT_ADOPTOPENJDK}\"} default button 1${DialogWithIcon}" \
 				-e "set response to button returned of the result" \
-				-e "if response is \"${MSG_VISIT_JAVA_DOT_COM}\" then open location \"http://java.com\""
+				-e "if response is \"${MSG_VISIT_JAVA_DOT_COM}\" then open location \"https://www.java.com/download/\"" \
+				-e "if response is \"${MSG_VISIT_ADOPTOPENJDK}\" then open location \"https://adoptopenjdk.net/releases.html\""
 		# exit with error
 		exit 3
 
@@ -727,9 +732,10 @@ if [ -z "${JAVACMD}" ] || [ ! -x "${JAVACMD}" ] ; then
 		# log exit cause
 		stub_logger "[EXIT 1] ${MSG_ERROR_LAUNCHING}"
 		# display error message with AppleScript
-		osascript -e "tell application \"System Events\" to display dialog \"${MSG_ERROR_LAUNCHING}\n\n${MSG_INSTALL_JAVA}\" with title \"${CFBundleName}\" buttons {\"${MSG_LATER}\", \"${MSG_VISIT_JAVA_DOT_COM}\"} default button \"${MSG_VISIT_JAVA_DOT_COM}\"${DialogWithIcon}" \
+		osascript -e "tell application \"System Events\" to display dialog \"${MSG_ERROR_LAUNCHING}\n\n${MSG_INSTALL_JAVA}\" with title \"${CFBundleName}\" buttons {\"${MSG_LATER}\", \"${MSG_VISIT_JAVA_DOT_COM}\", \"${MSG_VISIT_ADOPTOPENJDK}\"} default button 1${DialogWithIcon}" \
 					-e "set response to button returned of the result" \
-					-e "if response is \"${MSG_VISIT_JAVA_DOT_COM}\" then open location \"http://java.com\""
+					-e "if response is \"${MSG_VISIT_JAVA_DOT_COM}\" then open location \"https://www.java.com/download/\"" \
+					-e "if response is \"${MSG_VISIT_ADOPTOPENJDK}\" then open location \"https://adoptopenjdk.net/releases.html\""
 		# exit with error
 		exit 1
 	fi


### PR DESCRIPTION
* If java is missing, offer a choice between Oracle and AdoptOpenJDK download buttons (#78)
* Support Array style `Java:Arguments` for Apple Plist style (#76)
* Bugfix: do not crash if `CFBundleIconFile` is provided without ".icns" extension (#75)
* Minor French translation fix (PR #73, Thanks to @ebourg for his contribution)